### PR TITLE
Feature/kerim/roles

### DIFF
--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/controller/MemberController.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/controller/MemberController.java
@@ -1,7 +1,13 @@
 package edu.miu.cs.cs544.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import edu.miu.cs.cs544.dto.ErrorResponseDTO;
+import edu.miu.cs.cs544.service.MemberService;
+import edu.miu.cs.cs544.service.exception.MemberNotFoundException;
+import edu.miu.cs.cs544.service.exception.RoleNotFoundException;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import edu.miu.common.controller.BaseReadWriteController;
 import edu.miu.cs.cs544.domain.Member;
@@ -9,5 +15,78 @@ import edu.miu.cs.cs544.service.contract.MemberPayload;
 
 @RestController
 @RequestMapping("/members")
+@AllArgsConstructor
 public class MemberController extends BaseReadWriteController<MemberPayload, Member, Long> {
+
+    private final MemberService memberService;
+
+    @RequestMapping(value = "/{memberId}/roles", method = RequestMethod.GET)
+    ResponseEntity<?> getRoles(@PathVariable long memberId){
+        try {
+            return new ResponseEntity<>(
+                    memberService.getRoles(memberId),
+                    HttpStatusCode.valueOf(200)
+            );
+        } catch (MemberNotFoundException e) {
+            return new ResponseEntity<>(
+                    new ErrorResponseDTO(
+                            404,
+                            "Could not find a member with id " + e.requestedMemberId
+                    ),
+                    HttpStatusCode.valueOf(404)
+            );
+        }
+    }
+
+    @RequestMapping(value = "/{memberId}/roles/{roleId}", method = RequestMethod.POST)
+    ResponseEntity<?> assignRole(@PathVariable long memberId, @PathVariable Long roleId) {
+        try {
+            return new ResponseEntity<>(
+                    memberService.assignRole(roleId,memberId),
+                    HttpStatusCode.valueOf(200)
+            );
+        } catch (MemberNotFoundException e) {
+            return new ResponseEntity<>(
+              new ErrorResponseDTO(
+                      404,
+                      "Could not find a member with id " + e.requestedMemberId
+              ),
+                    HttpStatusCode.valueOf(404)
+            );
+        } catch (RoleNotFoundException e) {
+            return new ResponseEntity<>(
+                    new ErrorResponseDTO(
+                            404,
+                            "Could not find a role with id " + e.requestedRoleId
+                            ),
+                    HttpStatusCode.valueOf(404)
+            );
+        }
+    }
+
+    @RequestMapping(value = "/{memberId}/roles/{roleId}", method = RequestMethod.DELETE)
+    ResponseEntity<?> removeRole(@PathVariable long memberId, @PathVariable long roleId){
+        try {
+            return new ResponseEntity<>(
+                    memberService.removeRole(roleId, memberId),
+                    HttpStatusCode.valueOf(200)
+            );
+        } catch (MemberNotFoundException e) {
+            return new ResponseEntity<>(
+                    new ErrorResponseDTO(
+                            404,
+                            "Could not find a member with id " + e.requestedMemberId
+                    ),
+                    HttpStatusCode.valueOf(404)
+            );
+        } catch (RoleNotFoundException e) {
+            return new ResponseEntity<>(
+                    new ErrorResponseDTO(
+                            404,
+                            "Could not find a role with id " + e.requestedRoleId
+                    ),
+                    HttpStatusCode.valueOf(404)
+            );
+        }
+    }
 }

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/controller/RoleController.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/controller/RoleController.java
@@ -1,0 +1,12 @@
+package edu.miu.cs.cs544.controller;
+
+import edu.miu.common.controller.BaseReadWriteController;
+import edu.miu.cs.cs544.domain.Role;
+import edu.miu.cs.cs544.service.contract.RolePayload;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/roles")
+public class RoleController extends BaseReadWriteController<RolePayload, Role, Long> {
+}

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/domain/Member.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/domain/Member.java
@@ -4,7 +4,6 @@ import edu.miu.common.domain.AuditData;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/domain/Member.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/domain/Member.java
@@ -4,6 +4,7 @@ import edu.miu.common.domain.AuditData;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -36,7 +37,7 @@ public class Member implements Serializable {
     joinColumns = {@JoinColumn(name = "member_id")},
     inverseJoinColumns = {@JoinColumn(name = "role_id")})
     private Set<Role> role = new HashSet<>();
-    @OneToMany(cascade = CascadeType.PERSIST)
+    @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "member_id")
     private List<Account> accounts = new ArrayList<>();
     @Embedded

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/domain/Role.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/domain/Role.java
@@ -23,10 +23,10 @@ public class Role implements Serializable {
     @Column(nullable = false)
     private String name;
     @Embedded
-    AuditData auditData = new AuditData();
+    private AuditData auditData = new AuditData();
 
     @ElementCollection(targetClass = AccountType.class)
     @Enumerated(EnumType.STRING)
     @CollectionTable(name = "role_default_account_types", joinColumns = @JoinColumn(name = "role_id"))
-    Set<AccountType> defaultAccountTypes = new HashSet<>();
+    private Set<AccountType> defaultAccountTypes = new HashSet<>();
 }

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/dto/ErrorResponseDTO.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/dto/ErrorResponseDTO.java
@@ -1,0 +1,7 @@
+package edu.miu.cs.cs544.dto;
+
+public record ErrorResponseDTO(
+        int statusCode,
+        String message
+) {
+}

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/dto/MemberRolesResponseDTO.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/dto/MemberRolesResponseDTO.java
@@ -1,0 +1,11 @@
+package edu.miu.cs.cs544.dto;
+
+import edu.miu.cs.cs544.domain.Role;
+
+import java.util.Collection;
+
+public record MemberRolesResponseDTO(
+        long memberId,
+        Collection<Role> roles
+) {
+}

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/dto/ModifyMemberRoleResponseDTO.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/dto/ModifyMemberRoleResponseDTO.java
@@ -1,0 +1,13 @@
+package edu.miu.cs.cs544.dto;
+
+import edu.miu.cs.cs544.domain.Account;
+import edu.miu.cs.cs544.domain.Role;
+
+import java.util.Collection;
+
+public record ModifyMemberRoleResponseDTO(
+        long memberId,
+        Collection<Role> roles,
+        Collection<Account> accounts
+) {
+}

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/repository/RoleRepository.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/repository/RoleRepository.java
@@ -2,8 +2,13 @@ package edu.miu.cs.cs544.repository;
 
 import edu.miu.common.repository.BaseRepository;
 import edu.miu.cs.cs544.domain.Role;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RoleRepository extends BaseRepository<Role, Long> {
+    @Modifying
+    @Query(value = "DELETE FROM member_role WHERE role_id in (:roleIds)", nativeQuery = true)
+    void deleteAllRoleRefsInMemberRole(Iterable<Long> roleIds);
 }

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/repository/RoleRepository.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/repository/RoleRepository.java
@@ -1,0 +1,9 @@
+package edu.miu.cs.cs544.repository;
+
+import edu.miu.common.repository.BaseRepository;
+import edu.miu.cs.cs544.domain.Role;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoleRepository extends BaseRepository<Role, Long> {
+}

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/MemberService.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/MemberService.java
@@ -2,8 +2,18 @@ package edu.miu.cs.cs544.service;
 
 import edu.miu.common.service.BaseReadWriteService;
 import edu.miu.cs.cs544.domain.Member;
+import edu.miu.cs.cs544.dto.MemberRolesResponseDTO;
 import edu.miu.cs.cs544.service.contract.MemberPayload;
+import edu.miu.cs.cs544.dto.ModifyMemberRoleResponseDTO;
+import edu.miu.cs.cs544.service.exception.MemberNotFoundException;
+import edu.miu.cs.cs544.service.exception.RoleNotFoundException;
 
 
 public interface MemberService extends BaseReadWriteService<MemberPayload, Member, Long> {
+
+    MemberRolesResponseDTO getRoles(long memberId) throws MemberNotFoundException;
+
+    ModifyMemberRoleResponseDTO assignRole(long roleId, long memberId) throws MemberNotFoundException, RoleNotFoundException;
+
+    ModifyMemberRoleResponseDTO removeRole(long roleId, long memberId) throws MemberNotFoundException, RoleNotFoundException;
 }

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/MemberServiceImpl.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/MemberServiceImpl.java
@@ -1,10 +1,84 @@
 package edu.miu.cs.cs544.service;
 
 import edu.miu.common.service.BaseReadWriteServiceImpl;
+import edu.miu.cs.cs544.domain.Account;
 import edu.miu.cs.cs544.domain.Member;
+import edu.miu.cs.cs544.dto.MemberRolesResponseDTO;
+import edu.miu.cs.cs544.dto.ModifyMemberRoleResponseDTO;
+import edu.miu.cs.cs544.repository.MemberRepository;
+import edu.miu.cs.cs544.repository.RoleRepository;
 import edu.miu.cs.cs544.service.contract.MemberPayload;
+import edu.miu.cs.cs544.service.exception.MemberNotFoundException;
+import edu.miu.cs.cs544.service.exception.RoleNotFoundException;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
+@AllArgsConstructor
 public class MemberServiceImpl extends BaseReadWriteServiceImpl<MemberPayload, Member, Long> implements MemberService {
+
+    private final MemberRepository memberRepository;
+    private final RoleRepository roleRepository;
+
+
+    @Override
+    public MemberRolesResponseDTO getRoles(long memberId) throws MemberNotFoundException {
+        final var member = memberRepository.findById(memberId).orElseThrow(
+                () -> new MemberNotFoundException(memberId)
+        );
+        return new MemberRolesResponseDTO(
+                memberId,
+                List.copyOf(member.getRole())
+        );
+    }
+
+    @Transactional
+    @Override
+    public ModifyMemberRoleResponseDTO assignRole(long roleId, long memberId) throws MemberNotFoundException, RoleNotFoundException {
+        final var member = memberRepository.findById(memberId).orElseThrow(
+                () -> new MemberNotFoundException(memberId)
+        );
+        final var role = roleRepository.findById(roleId).orElseThrow(() -> new RoleNotFoundException(roleId));
+        final var memberRoles = member.getRole();
+        final var memberAccounts = member.getAccounts();
+        final var supportedAccountTypes = memberAccounts.stream().map(Account::getType).collect(Collectors.toSet());
+        final var notYetSupportedAccountTypes = new HashSet<>(role.getDefaultAccountTypes());
+        notYetSupportedAccountTypes.removeAll(supportedAccountTypes);
+        memberRoles.add(role);
+        for (final var accountType : notYetSupportedAccountTypes) {
+            memberAccounts.add(
+                    new Account(
+                            "", "", accountType
+                    )
+            );
+        }
+        memberRepository.save(member);
+        return new ModifyMemberRoleResponseDTO(
+                memberId,
+                List.copyOf(member.getRole()),
+                List.copyOf(memberAccounts)
+        );
+    }
+
+    @Transactional
+    @Override
+    public ModifyMemberRoleResponseDTO removeRole(long roleId, long memberId) throws MemberNotFoundException, RoleNotFoundException {
+        final var member = memberRepository.findById(memberId).orElseThrow(
+                () -> new MemberNotFoundException(memberId)
+        );
+        final var role = roleRepository.findById(roleId).orElseThrow(
+                () -> new RoleNotFoundException(roleId)
+        );
+        member.getRole().remove(role);
+        memberRepository.save(member);
+        return new ModifyMemberRoleResponseDTO(
+                memberId,
+                List.copyOf(member.getRole()),
+                List.copyOf(member.getAccounts())
+        );
+    }
 }

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/RoleService.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/RoleService.java
@@ -1,0 +1,8 @@
+package edu.miu.cs.cs544.service;
+
+import edu.miu.common.service.BaseReadWriteService;
+import edu.miu.cs.cs544.domain.Role;
+import edu.miu.cs.cs544.service.contract.RolePayload;
+
+public interface RoleService extends BaseReadWriteService<RolePayload, Role, Long> {
+}

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/RoleServiceImpl.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/RoleServiceImpl.java
@@ -2,9 +2,30 @@ package edu.miu.cs.cs544.service;
 
 import edu.miu.common.service.BaseReadWriteServiceImpl;
 import edu.miu.cs.cs544.domain.Role;
+import edu.miu.cs.cs544.repository.RoleRepository;
 import edu.miu.cs.cs544.service.contract.RolePayload;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
+@AllArgsConstructor
 public class RoleServiceImpl extends BaseReadWriteServiceImpl<RolePayload, Role, Long> implements RoleService {
+    private final RoleRepository roleRepository;
+
+    @Transactional
+    @Override
+    public void deleteInBatch(Iterable<Long> ids) {
+        roleRepository.deleteAllRoleRefsInMemberRole(ids);
+        super.deleteInBatch(ids);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Long id) {
+        roleRepository.deleteAllRoleRefsInMemberRole(List.of(id));
+        super.delete(id);
+    }
 }

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/RoleServiceImpl.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/RoleServiceImpl.java
@@ -1,0 +1,10 @@
+package edu.miu.cs.cs544.service;
+
+import edu.miu.common.service.BaseReadWriteServiceImpl;
+import edu.miu.cs.cs544.domain.Role;
+import edu.miu.cs.cs544.service.contract.RolePayload;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoleServiceImpl extends BaseReadWriteServiceImpl<RolePayload, Role, Long> implements RoleService {
+}

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/contract/MemberPayload.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/contract/MemberPayload.java
@@ -1,14 +1,10 @@
 package edu.miu.cs.cs544.service.contract;
 
 import edu.miu.common.domain.AuditData;
-import edu.miu.cs.cs544.domain.Account;
-import edu.miu.cs.cs544.domain.Role;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.io.Serializable;
-import java.util.List;
-import java.util.Set;
 
 @Data
 @AllArgsConstructor
@@ -25,10 +21,6 @@ public class MemberPayload implements Serializable {
     private String email;
 
     private String barCode;
-
-    private Set<Role> role;
-
-    private List<Account> accounts;
 
     private AuditData auditData;
 

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/contract/RolePayload.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/contract/RolePayload.java
@@ -1,0 +1,20 @@
+package edu.miu.cs.cs544.service.contract;
+import edu.miu.common.domain.AuditData;
+import edu.miu.cs.cs544.domain.AccountType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.Set;
+
+@Data
+@AllArgsConstructor
+public class RolePayload implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private long id;
+    private String name;
+    private AuditData auditData;
+    private Set<AccountType> defaultAccountTypes;
+}

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/exception/MemberNotFoundException.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/exception/MemberNotFoundException.java
@@ -1,0 +1,9 @@
+package edu.miu.cs.cs544.service.exception;
+
+public class MemberNotFoundException extends Exception {
+    public final long requestedMemberId;
+
+    public MemberNotFoundException(long requestedMemberId) {
+        this.requestedMemberId = requestedMemberId;
+    }
+}

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/exception/RoleNotFoundException.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/exception/RoleNotFoundException.java
@@ -1,0 +1,10 @@
+package edu.miu.cs.cs544.service.exception;
+
+public class RoleNotFoundException extends Exception {
+
+    public final long requestedRoleId;
+
+    public RoleNotFoundException(long requestedRoleId) {
+        this.requestedRoleId = requestedRoleId;
+    }
+}

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/mapper/RolePayloadToRoleMapper.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/mapper/RolePayloadToRoleMapper.java
@@ -1,0 +1,14 @@
+package edu.miu.cs.cs544.service.mapper;
+
+import edu.miu.common.service.mapper.BaseMapper;
+import edu.miu.cs.cs544.domain.Role;
+import edu.miu.cs.cs544.service.contract.RolePayload;
+import ma.glasnost.orika.MapperFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RolePayloadToRoleMapper extends BaseMapper<RolePayload, Role> {
+    public RolePayloadToRoleMapper(MapperFactory mapperFactory) {
+        super(mapperFactory, RolePayload.class, Role.class);
+    }
+}

--- a/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/mapper/RoleToRolePayloadMapper.java
+++ b/cs544-202403-project/src/main/java/edu/miu/cs/cs544/service/mapper/RoleToRolePayloadMapper.java
@@ -1,0 +1,14 @@
+package edu.miu.cs.cs544.service.mapper;
+
+import edu.miu.common.service.mapper.BaseMapper;
+import edu.miu.cs.cs544.domain.Role;
+import edu.miu.cs.cs544.service.contract.RolePayload;
+import ma.glasnost.orika.MapperFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoleToRolePayloadMapper extends BaseMapper<Role, RolePayload> {
+    public RoleToRolePayloadMapper(MapperFactory mapperFactory) {
+        super(mapperFactory, Role.class, RolePayload.class);
+    }
+}


### PR DESCRIPTION
- Added features `assignRole`, `removeRole` and `getRoles` per Member.
- Implemented the basic CRUD on Roles alone using the professor's framework
- For the advanced use-case I defined `MemberRolesResponseDTO` and `ModifyMemberRolesResponseDTO` since it's impossible to map them into a single payload in new defined `dto` package in the root scope
- I defined `service.exception` package for checked exceptions occurred in the service layer
- Since, relationship between `Member` and `Role` is many-to-many, deleting `Role` throws an exception claiming into integrity violation (the `member_role` table requires `role_id` not to be null). In order to resolve the exception, I defined a query `void deleteAllRoleRefsInMemberRole(Iterable<Long> roleIds);` in `RoleRepository`. Why is it a native SQL query? HSQL syntax does not allow to pick the link tables, that's why I used the native query. And with that, I overrode the corresponding methods in `RoleServiceImpl` to delete the role references in the `member_role` link table and only then calling methods of the super class
- When assigning a role to a member, new accounts are to be generated in accordance with default types of a role. If a member already has an account of the account type present in the set of default accounts of a role, then generation for that account type is omitted. Check `assignRole` in `MemberServiceImpl`